### PR TITLE
Feature: Remove linking AFNetworking's UIKit subspec

### DIFF
--- a/ChatSDK.podspec
+++ b/ChatSDK.podspec
@@ -29,10 +29,10 @@ Pod::Spec.new do |s|
 	  }
 
 	  core.dependency 'RXPromise', '~> 1.0'
-	  core.dependency 'AFNetworking/Reachability'
-	  core.dependency 'AFNetworking/Serialization'
-	  core.dependency 'AFNetworking/Security'
-	  core.dependency 'AFNetworking/NSURLSession'
+	  core.dependency 'AFNetworking/Reachability', '~> 3.2.1'
+	  core.dependency 'AFNetworking/Serialization', '~> 3.2.1'
+	  core.dependency 'AFNetworking/Security', '~> 3.2.1'
+	  core.dependency 'AFNetworking/NSURLSession', '~> 3.2.1'
 	  core.dependency 'DateTools', '~> 2.0'
       core.dependency 'SAMKeychain'
 

--- a/ChatSDK.podspec
+++ b/ChatSDK.podspec
@@ -29,7 +29,10 @@ Pod::Spec.new do |s|
 	  }
 
 	  core.dependency 'RXPromise', '~> 1.0'
-	  core.dependency 'AFNetworking', '~>3.2.1'
+	  core.dependency 'AFNetworking/Reachability'
+	  core.dependency 'AFNetworking/Serialization'
+	  core.dependency 'AFNetworking/Security'
+	  core.dependency 'AFNetworking/NSURLSession'
 	  core.dependency 'DateTools', '~> 2.0'
       core.dependency 'SAMKeychain'
 

--- a/ChatSDKCore/Classes/Core.h
+++ b/ChatSDKCore/Classes/Core.h
@@ -13,7 +13,6 @@
 
 #import <RXPromise/RXPromise.h>
 #import <RXPromise/RXPromise+RXExtension.h>
-#import <AFNetworking/AFNetworking.h>
 #import <DateTools/NSDate+DateTools.h>
 
 #import <ChatSDK/NSArray+KeyPair.h>

--- a/ChatSDKCore/Classes/Utilities/BCoreUtilities.m
+++ b/ChatSDKCore/Classes/Utilities/BCoreUtilities.m
@@ -8,7 +8,8 @@
 
 #import "BCoreUtilities.h"
 //#import <DateTools.h>
-#import <ChatSDK/Core.h> 
+#import <ChatSDK/Core.h>
+#import "AFHTTPSessionManager.h"
 
 @implementation BCoreUtilities
 

--- a/ChatSDKUI/Classes/Actions/BSelectMediaAction.m
+++ b/ChatSDKUI/Classes/Actions/BSelectMediaAction.m
@@ -8,6 +8,7 @@
 #import "BSelectMediaAction.h"
 #import <ChatSDK/Core.h>
 #import <ChatSDK/UI.h>
+#import <MobileCoreServices/MobileCoreServices.h>
 
 @implementation BSelectMediaAction
 


### PR DESCRIPTION
### [Link to the Asana issue](https://app.asana.com/0/538376454627116/1142125328929717/f)

### Description
- [This is the GitHub issue about removing the reference to `UIWebView`](https://github.com/AFNetworking/AFNetworking/issues/4428). There are PRs opened to address it, but none of them are currently merged into their `master` branch.

### What has changed
The only good way we can solve the issue at the moment is to follow [this suggestion](https://github.com/AFNetworking/AFNetworking/issues/4428#issuecomment-527956472) where we link all of the pod's subspecs except the one referencing `UIWebView`. This means that we lose the ability to import `<AFNetworking/AFNetworking.h>` and have to import more specific headers.